### PR TITLE
Revert "tasks/configure.yml: Validate systemd unit files"

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -70,7 +70,6 @@
     mode: 0644
     owner: root
     group: root
-    validate: systemd-analyze verify %s
   register: unitfile
   vars:
     pg_ctl_path: "/usr/lib/postgresql/{{ pg_ver.stdout }}/bin/pg_ctl"


### PR DESCRIPTION
Reverts stuvusIT/postgresql#31
Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232